### PR TITLE
feat: Responsive navbar layout for logo and nav links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -63,10 +63,12 @@ p {
 /* Navigation */
 .navbar{
     display: grid;
-    grid-template-columns: 1fr auto 1fr;
+    grid-template-rows: auto 1fr;
+    grid-auto-columns: 1fr;
     align-items: center;
     text-align: center;
-    padding: 0 2.563rem;
+    /*padding: 0 2.563rem;*/
+    padding: 0 6.563rem;
 }
 
 .logo {
@@ -75,11 +77,10 @@ p {
     text-transform: uppercase;
     letter-spacing: -0.219rem;
     color: var(--logo-color);
-    grid-column: 2;
+    text-align: center;
 }
 
 .header-nav-links {
-    grid-column: 3;
     display: flex;
     justify-content: flex-end;
 }
@@ -218,7 +219,21 @@ nav[logged-in="false"] {
 /*MEDIA QUERY SCREEN SIZES*/
 /*Tablet (M)*/
 @media (min-width: 768px) {
+    /* Navigation */
+    .navbar{
+        grid-template-rows: 1fr;
+        grid-template-columns: 1fr auto 1fr;
+    }
 
+    .logo {
+        grid-column: 2;
+        text-align: unset;
+    }
+
+    .header-nav-links {
+        grid-column: 3;
+        justify-content: flex-end;
+    }
 }
 
 /*Desktop (XL) */


### PR DESCRIPTION
On mobile screens (less than 768px wide):
- The logo is displayed on top, centered horizontally.
- The navigation links are stacked below the logo, justified to the right end.

On desktop screens (1280px wide and above):
- The logo and navigation links are displayed on the same row.
- The logo remains centered horizontally.
- The navigation links are justified to the right end.